### PR TITLE
fix: repo link to AugmentOS-Community in how-to.md

### DIFF
--- a/augmentos_docs/docs/tutorial/how-to.md
+++ b/augmentos_docs/docs/tutorial/how-to.md
@@ -72,9 +72,9 @@ You're now running an AugmentOS TPA!
 
 ## **AugmentOSLib installation**
 
-1. Clone the [AugmentOS repository](https://github.com/augmentos/augmentos) next to your app's directory (default setup)
+1. Clone the [AugmentOS repository](https://github.com/AugmentOS-Community/AugmentOS) next to your app's directory (default setup)
 
-2. If you cloned the [AugmentOS repository](https://github.com/augmentos/augmentos) elsewhere, update the path to AugmentOSLib in `settings.gradle`:
+2. If you cloned the [AugmentOS repository](https://github.com/AugmentOS-Community/AugmentOS) elsewhere, update the path to AugmentOSLib in `settings.gradle`:
    ```
    project(':AugmentOSLib').projectDir = new File(rootProject.projectDir, '../AugmentOS/augmentos_android_library/AugmentOSLib')
    ```


### PR DESCRIPTION
The link pointed to an incorrect GitHub user/organization, preventing it from resolving. This commit corrects the link to the proper AugmentOS-Community repository.

I don't think it was supposed to link to a GitHub profile that has 'augmentos' as their username, right? :p