### PR TITLE
add cloud and sdk support for TPA tools that can be called by Mira

### DIFF
--- a/augmentos_cloud/packages/cloud/src/index.ts
+++ b/augmentos_cloud/packages/cloud/src/index.ts
@@ -29,6 +29,7 @@ import devRoutes from './routes/developer.routes';
 import serverRoutes from './routes/server.routes';
 import adminRoutes from './routes/admin.routes';
 import tpaServerRoutes from './routes/tpa-server.routes';
+import toolsRoutes from './routes/tools.routes';
 
 import path from 'path';
 
@@ -81,10 +82,8 @@ app.use(cors({
     'http://127.0.0.1:5173',
     'http://localhost:5173',
     'http://127.0.0.1:5174',
-    'http://localhost:5173',
     'http://localhost:5174',
-    'http://localhost:5175',
-    'http://localhost:5176',
+    'http://localhost:5173',
     'http://localhost:53216',
     'http://localhost:6173',
     'https://cloud.augmentos.org',
@@ -128,7 +127,7 @@ app.use('/api/dev', devRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/tpa-server', tpaServerRoutes);
 app.use('/api/server', serverRoutes);
-
+app.use('/api/tools', toolsRoutes);
 app.use(errorReportRoutes);
 app.use(transcriptRoutes);
 

--- a/augmentos_cloud/packages/cloud/src/models/app.model.ts
+++ b/augmentos_cloud/packages/cloud/src/models/app.model.ts
@@ -1,8 +1,10 @@
 // cloud/server/src/models/app.model.ts
 import mongoose, { Schema, Document, Types } from 'mongoose';
-import { AppI as _AppI, TpaType } from '@augmentos/sdk';
+import { AppI as _AppI, TpaType, ToolSchema, ToolParameterSchema } from '@augmentos/sdk';
 
 export type AppStoreStatus = 'DEVELOPMENT' | 'SUBMITTED' | 'REJECTED' | 'PUBLISHED';
+
+
 
 // Extend the AppI interface for our MongoDB document
 export interface AppI extends _AppI, Document {
@@ -15,6 +17,7 @@ export interface AppI extends _AppI, Document {
   reviewNotes?: string;
   reviewedBy?: string;
   reviewedAt?: Date;
+  tools?: ToolSchema[];
 }
 
 // Using existing schema with flexible access
@@ -42,7 +45,46 @@ const AppSchema = new Schema({
   },
   reviewedAt: {
     type: Date
-  }
+  },
+  
+  // TPA AI Tools
+  tools: [{
+    id: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      required: true
+    },
+    activationPhrases: {
+      type: [String],
+      required: false
+    },
+    parameters: {
+      type: Map,
+      of: new Schema({
+        type: {
+          type: String,
+          enum: ['string', 'number', 'boolean'],
+          required: true
+        },
+        description: {
+          type: String,
+          required: true
+        },
+        enum: {
+          type: [String],
+          required: false
+        },
+        required: {
+          type: Boolean,
+          default: false
+        }
+      }),
+      required: false
+    }
+  }]
 }, { 
   strict: false,
   timestamps: true 

--- a/augmentos_cloud/packages/cloud/src/routes/tools.routes.ts
+++ b/augmentos_cloud/packages/cloud/src/routes/tools.routes.ts
@@ -1,0 +1,148 @@
+// routes/tools.routes.ts
+import { Router, Request, Response } from 'express';
+import App from '../models/app.model';
+import { logger } from '@augmentos/utils';
+import { Exception } from '@sentry/node';
+import appService from '../services/core/app.service';
+import { User } from '../models/user.model';
+import { ToolCall } from '@augmentos/sdk';
+const router = Router();
+/**
+ * Trigger a tool webhook to a TPA
+ * Used by Mira AI to send tools to TPAs
+ */
+const triggerTool = async (req: Request, res: Response) => {
+  try {
+    console.log('🔨 Triggering tool for:', req.params.packageName);
+    console.log('🔨 Payload:', req.body);
+    const { packageName } = req.params;
+    const payload: ToolCall = req.body;
+    
+    // Validate the payload has the required fields
+    if (!payload.toolId) {
+      return res.status(400).json({ 
+        error: true, 
+        message: 'Missing required fields: toolId' 
+      });
+    }
+    if (!payload.userId) {
+      return res.status(400).json({ 
+        error: true, 
+        message: 'Missing required fields: userId' 
+      });
+    }
+    
+
+    // Log the tool request
+    logger.info(`Triggering tool webhook for app ${packageName}`, {
+      toolId: payload.toolId,
+      userId: payload.userId
+    });
+    
+    // Call the service method to trigger the webhook
+    const result = await appService.triggerTpaToolWebhook(packageName, payload);
+    
+    // Return the response from the TPA
+    return res.status(result.status).json(result.data);
+  } catch (error) {
+    logger.error('Error triggering tool webhook:', error);
+    return res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+  };
+  
+  /**
+   * Get all tools for a specific TPA
+   * Used by Mira AI to discover available tools
+   */
+  const getTpaTools = async (req: Request, res: Response) => {
+  try {
+    const { packageName } = req.params;
+    
+    // Call the service method to get the tools
+    const tools = await appService.getTpaTools(packageName);
+    
+    // Return the tools array
+    res.json(tools);
+  } catch (error) {
+    logger.error('Error fetching TPA tools:', error);
+    res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+  };
+  
+  /**
+   * Get all tools for a user's installed TPAs
+   * Used by Mira AI to discover all available tools for a user
+   */
+  const getUserTools = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    
+    if (!userId) {
+    return res.status(400).json({ 
+      error: true, 
+      message: 'Missing required parameter: userId' 
+    });
+    }
+    
+    // Find the user by userId (email)
+    const user = await User.findOne({ email: userId });
+    
+    if (!user) {
+    return res.status(404).json({ 
+      error: true, 
+      message: 'User not found' 
+    });
+    }
+    
+    // Get list of installed app packageNames from user
+    const installedPackageNames = user.installedApps?.map(app => app.packageName) || [];
+    
+    if (installedPackageNames.length === 0) {
+    return res.json([]);
+    }
+    
+    // Collect all tools from all installed apps
+    const allUserTools = [];
+    
+    for (const packageName of installedPackageNames) {
+    try {
+      // Get tools for this app
+      const appTools = await appService.getTpaTools(packageName);
+      
+      // Add app identifier to each tool
+      const toolsWithAppInfo = appTools.map(tool => ({
+      ...tool,
+      appPackageName: packageName
+      }));
+      
+      allUserTools.push(...toolsWithAppInfo);
+    } catch (error) {
+      // Log error but continue with other apps
+      logger.error(`Error fetching tools for app ${packageName}:`, error);
+    }
+    }
+    
+    // Return the combined list of tools
+    res.json(allUserTools);
+  } catch (error) {
+    logger.error('Error fetching user tools:', error);
+    res.status(500).json({ 
+    error: true,
+    message: error instanceof Error ? error.message : 'Unknown error occurred' 
+    });
+  }
+};
+  
+
+// Tool webhook routes - Used by Mira AI
+router.post('/apps/:packageName/tool', triggerTool);
+router.get('/apps/:packageName/tools', getTpaTools);
+router.get('/users/:userId/tools', getUserTools);
+
+export default router;

--- a/augmentos_cloud/packages/cloud/src/services/core/app.service.ts
+++ b/augmentos_cloud/packages/cloud/src/services/core/app.service.ts
@@ -7,16 +7,17 @@
  * to maintain core functionality regardless of database state.
  */
 
-import { AppI, StopWebhookRequest, TpaType, WebhookResponse, AppState, SessionWebhookRequest } from '@augmentos/sdk';
+import { AppI, StopWebhookRequest, TpaType, WebhookResponse, AppState, SessionWebhookRequest, ToolCall } from '@augmentos/sdk';
 import axios, { AxiosError } from 'axios';
 import { systemApps } from './system-apps';
 import App from '../../models/app.model';
+import { ToolSchema, ToolParameterSchema } from '@augmentos/sdk';
 import { User } from '../../models/user.model';
 import crypto from 'crypto';
 
 const AUGMENTOS_AUTH_JWT_SECRET = process.env.AUGMENTOS_AUTH_JWT_SECRET;
 const APPSTORE_ENABLED = true;
-export const PRE_INSTALLED = ["com.augmentos.livecaptions", "cloud.augmentos.notify", "cloud.augmentos.mira"];
+export const PRE_INSTALLED = ["cloud.augmentos.live-captions", "cloud.augmentos.notify", "cloud.augmentos.mira"];
 
 /**
  * System TPAs that are always available.
@@ -371,13 +372,84 @@ export class AppService {
   }
 
   /**
+   * Validates tool definitions against the schema requirements
+   * @param tools Array of tool definitions to validate
+   * @returns Validated and sanitized tools array or throws error if invalid
+   */
+  private validateToolDefinitions(tools: any[]): ToolSchema[] {
+    console.log('Validating tool definitions:', tools);
+    if (!Array.isArray(tools)) {
+      throw new Error('Tools must be an array');
+    }
+    
+    return tools.map(tool => {
+      // Validate required fields
+      if (!tool.id || typeof tool.id !== 'string') {
+        throw new Error('Tool id is required and must be a string');
+      }
+      
+      if (!tool.description || typeof tool.description !== 'string') {
+        throw new Error('Tool description is required and must be a string');
+      }
+      
+      // Activation phrases can be null or empty, no validation needed
+      // We'll just ensure it's an array if provided
+      if (tool.activationPhrases && !Array.isArray(tool.activationPhrases)) {
+        throw new Error('Tool activationPhrases must be an array if provided');
+      }
+      
+      // Validate parameters if they exist
+      const validatedParameters: Record<string, ToolParameterSchema> = {};
+      
+      if (tool.parameters) {
+        Object.entries(tool.parameters).forEach(([key, param]: [string, any]) => {
+          if (!param.type || !['string', 'number', 'boolean'].includes(param.type)) {
+            throw new Error(`Parameter ${key} has invalid type. Must be string, number, or boolean`);
+          }
+          
+          if (!param.description || typeof param.description !== 'string') {
+            throw new Error(`Parameter ${key} requires a description`);
+          }
+          
+          validatedParameters[key] = {
+            type: param.type as 'string' | 'number' | 'boolean',
+            description: param.description,
+            required: !!param.required
+          };
+          
+          // Add enum values if present
+          if (param.enum && Array.isArray(param.enum)) {
+            validatedParameters[key].enum = param.enum;
+          }
+        });
+      }
+      
+      return {
+        id: tool.id,
+        description: tool.description,
+        activationPhrases: tool.activationPhrases.map((p: string) => p.trim()),
+        parameters: Object.keys(validatedParameters).length > 0 ? validatedParameters : undefined
+      };
+    });
+  }
+
+  /**
    * Create a new app
    */
   async createApp(appData: any, developerId: string): Promise<{ app: AppI, apiKey: string }> {
     // Generate API key
     const apiKey = crypto.randomBytes(32).toString('hex');
     const hashedApiKey = this.hashApiKey(apiKey);
-
+    
+    // Parse and validate tools if present
+    if (appData.tools) {
+      try {
+        appData.tools = this.validateToolDefinitions(appData.tools);
+      } catch (error: any) {
+        throw new Error(`Invalid tool definitions: ${error.message}`);
+      }
+    }
+    
     // Create app
     const app = await App.create({
       ...appData,
@@ -411,7 +483,16 @@ export class AppService {
     if (app.developerId.toString() !== developerId) {
       throw new Error('You do not have permission to update this app');
     }
-
+    
+    // Parse and validate tools if present
+    if (appData.tools) {
+      try {
+        appData.tools = this.validateToolDefinitions(appData.tools);
+      } catch (error: any) {
+        throw new Error(`Invalid tool definitions: ${error.message}`);
+      }
+    }
+    
     // If developerInfo is provided, ensure it's properly structured
     if (appData.developerInfo) {
       // Make sure only valid fields are included
@@ -604,6 +685,161 @@ export class AppService {
     return App.find({ appStoreStatus: 'PUBLISHED' });
   }
 
+  /**
+   * Triggers the TPA tool webhook for Mira AI integration
+   * @param packageName - The package name of the TPA to send the tool to
+   * @param payload - The tool webhook payload containing tool details
+   * @returns Promise resolving to the webhook response or error
+   */
+  async triggerTpaToolWebhook(packageName: string, payload: ToolCall): Promise<{
+    status: number;
+    data: any;
+  }> {
+    // Look up the TPA by packageName
+    const app = await this.getApp(packageName);
+
+    console.log('🔨 Triggering tool webhook for:', packageName);
+    
+    if (!app) {
+      throw new Error(`App ${packageName} not found`);
+    }
+    
+    if (!app.publicUrl) {
+      throw new Error(`App ${packageName} does not have a public URL`);
+    }
+    
+    // Get the app document from MongoDB
+    const appDoc = await App.findOne({ packageName });
+    if (!appDoc) {
+      throw new Error(`App ${packageName} not found in database`);
+    }
+    
+    // For security reasons, we can't retrieve the original API key
+    // Instead, we'll use a special header that identifies this as a system request
+    // The TPA server will need to validate this using the hashedApiKey
+    
+    // Construct the webhook URL from the app's public URL
+    const webhookUrl = `${app.publicUrl}/tool`;
+    
+    // Set up retry configuration
+    const maxRetries = 2;
+    const baseDelay = 1000; // 1 second
+
+    console.log('🔨 Sending tool webhook to:', webhookUrl);
+    console.log('🔨 Payload:', payload);
+    
+    // Attempt to send the webhook with retries
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const response = await axios.post(webhookUrl, payload, {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-TPA-API-Key': appDoc.hashedApiKey, // Use the hashed API key for authentication
+          },
+          timeout: 10000 // 10 second timeout
+        });
+        
+        // Return successful response
+        return {
+          status: response.status,
+          data: response.data
+        };
+      } catch (error: unknown) {
+        // If this is the last retry attempt, throw an error
+        if (attempt === maxRetries - 1) {
+          if (axios.isAxiosError(error)) {
+            const axiosError = error as AxiosError;
+            console.error(`Tool webhook failed for ${packageName}: ${axiosError.message}`);
+            console.error(`URL: ${webhookUrl}`);
+            console.error(`Response: ${axiosError.response?.data}`);
+            console.error(`Status: ${axiosError.response?.status}`);
+            
+            // Return a standardized error response
+            return {
+              status: axiosError.response?.status || 500,
+              data: {
+                error: true,
+                message: `Webhook failed: ${axiosError.message}`,
+                details: axiosError.response?.data || {}
+              }
+            };
+          } else {
+            // Handle non-Axios errors
+            const genericError = error as Error;
+            return {
+              status: 500,
+              data: {
+                error: true,
+                message: `Webhook failed: ${genericError.message || 'Unknown error'}`
+              }
+            };
+          }
+        }
+        
+        // Exponential backoff before retry
+        await new Promise(resolve => setTimeout(resolve, baseDelay * Math.pow(2, attempt)));
+      }
+    }
+    
+    // This should never be reached due to the error handling above,
+    // but TypeScript requires a return value
+    return {
+      status: 500,
+      data: {
+        error: true,
+        message: 'Unknown error occurred'
+      }
+    };
+  }
+
+  /**
+   * Gets all tool definitions for a TPA
+   * Used by Mira AI to discover available tools
+   * @param packageName - The package name of the TPA
+   * @returns Array of tool definitions
+   */
+  async getTpaTools(packageName: string): Promise<ToolSchema[]> {
+    // Look up the TPA by packageName
+    const app = await this.getApp(packageName);
+    
+    if (!app) {
+      throw new Error(`App ${packageName} not found`);
+    }
+    
+    if (!app.publicUrl) {
+      throw new Error(`App ${packageName} does not have a public URL`);
+    }
+
+    console.log('Getting TPA tools for:', packageName);
+    
+    try {
+      // Fetch the tpa_config.json from the app's publicUrl
+      const configUrl = `${app.publicUrl}/tpa_config.json`;
+      const response = await axios.get(configUrl, { timeout: 5000 });
+
+      // Check if the response contains a tools array
+      const config = response.data;
+      if (config && Array.isArray(config.tools)) {
+        // Validate the tools before returning them
+        console.log(`Found ${config.tools.length} tools in ${packageName}, validating...`);
+        return this.validateToolDefinitions(config.tools);
+      }
+      
+      // If no tools found, return empty array
+      return [];
+    } catch (error) {
+      // Check if error is a 404 (file not found) and silently ignore
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        // Config file doesn't exist, silently return empty array
+        console.log(`No tpa_config.json found for app ${packageName} (404)`);
+        return [];
+      }
+      
+      // Log other errors but still return empty array
+      //console.error(`Failed to fetch tpa_config.json for app ${packageName}:`, error);
+      return [];
+    }
+  }
 
 }
 

--- a/augmentos_cloud/packages/cloud/src/services/core/app.service.ts
+++ b/augmentos_cloud/packages/cloud/src/services/core/app.service.ts
@@ -17,7 +17,7 @@ import crypto from 'crypto';
 
 const AUGMENTOS_AUTH_JWT_SECRET = process.env.AUGMENTOS_AUTH_JWT_SECRET;
 const APPSTORE_ENABLED = true;
-export const PRE_INSTALLED = ["cloud.augmentos.live-captions", "cloud.augmentos.notify", "cloud.augmentos.mira"];
+export const PRE_INSTALLED = ["com.augmentos.livecaptions", "cloud.augmentos.notify", "cloud.augmentos.mira"];
 
 /**
  * System TPAs that are always available.

--- a/augmentos_cloud/packages/sdk/src/tpa/server/index.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/server/index.ts
@@ -14,7 +14,8 @@ import {
   SessionWebhookRequest,
   StopWebhookRequest,
   isSessionWebhookRequest,
-  isStopWebhookRequest
+  isStopWebhookRequest,
+  ToolCall
 } from '../../types';
 
 /**
@@ -109,6 +110,7 @@ export class TpaServer {
     this.setupWebhook();
     this.setupSettingsEndpoint();
     this.setupHealthCheck();
+    this.setupToolCallEndpoint();
     this.setupPublicDir();
     this.setupShutdown();
   }
@@ -150,6 +152,20 @@ export class TpaServer {
       session.disconnect();
       this.activeSessions.delete(sessionId);
     }
+  }
+
+  /**
+   * 🛠️ Tool Call Handler
+   * Override this method to handle tool calls from AugmentOS Cloud.
+   * This is where you implement your app's tool functionality.
+   * 
+   * @param toolCall - The tool call request containing tool details and parameters
+   * @returns Optional string response that will be sent back to AugmentOS Cloud
+   */
+  protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
+    console.log(`Tool call received: ${toolCall.toolId}`);
+    console.log(`Parameters: ${JSON.stringify(toolCall.toolParameters)}`);
+    return undefined;
   }
 
   /**
@@ -252,6 +268,38 @@ export class TpaServer {
           message: 'Internal server error'
         } as WebhookResponse);
       }
+    });
+  }
+
+  /**
+   * 🛠️ Setup Tool Call Endpoint
+   * Creates a /tool endpoint for handling tool calls from AugmentOS Cloud.
+   */
+  private setupToolCallEndpoint(): void {
+    this.app.post('/tool', async (req, res) => {
+      try {
+        console.log(`\n\n🔧 Received tool call: ${JSON.stringify(req.body)}\n\n`);
+        const toolCall = req.body as ToolCall;
+        console.log(`\n\n🔧 Received tool call: ${toolCall.toolId}\n\n`);
+        // Call the onToolCall handler and get the response
+        const response = await this.onToolCall(toolCall);
+        
+        // Send back the response if one was provided
+        if (response !== undefined) {
+          res.json({ status: 'success', reply: response });
+        } else {
+          res.json({ status: 'success', reply: null });
+        }
+      } catch (error) {
+        console.error('❌ Error handling tool call:', error);
+        res.status(500).json({
+          status: 'error',
+          message: error instanceof Error ? error.message : 'Unknown error occurred calling tool'
+        });
+      }
+    });
+    this.app.get('/tool', async (req, res) => {
+      res.json({ status: 'success', reply: 'Hello, world!' });
     });
   }
 

--- a/augmentos_cloud/packages/sdk/src/types/index.ts
+++ b/augmentos_cloud/packages/sdk/src/types/index.ts
@@ -82,7 +82,8 @@ export {
   AppStopped,
   SettingsUpdate,
   DataStream,
-  CloudToTpaMessage
+  CloudToTpaMessage,
+  ToolCall
 } from './messages/cloud-to-tpa';
 
 // From layout.ts
@@ -128,7 +129,9 @@ export {
   BaseAppSetting,
   GroupSetting,
   TpaConfig,
-  validateTpaConfig
+  validateTpaConfig,
+  ToolSchema,
+  ToolParameterSchema
 } from './models';
 
 

--- a/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
+++ b/augmentos_cloud/packages/sdk/src/types/messages/cloud-to-tpa.ts
@@ -91,6 +91,17 @@ export interface AudioChunk extends BaseMessage {
   sampleRate?: number;  // Audio sample rate (e.g., 16000 Hz)
 }
 
+/**
+ * Tool call from cloud to TPA
+ * Represents a tool invocation with filled parameters
+ */
+export interface ToolCall {
+  toolId: string; // The ID of the tool that was called
+  toolParameters: Record<string, string | number | boolean>; // The parameters of the tool that was called
+  timestamp: Date; // Timestamp when the tool was called
+  userId: string; // ID of the user who triggered the tool call
+}
+
 //===========================================================
 // Stream data
 //===========================================================

--- a/augmentos_cloud/packages/sdk/src/types/models.ts
+++ b/augmentos_cloud/packages/sdk/src/types/models.ts
@@ -3,6 +3,23 @@
 
 import { AppSettingType, AppState, Language, TpaType } from './enums';
 
+
+// Tool parameter type definition
+export interface ToolParameterSchema {
+  type: 'string' | 'number' | 'boolean';
+  description: string;
+  enum?: string[];
+  required?: boolean;
+}
+
+// Tool schema definition for TPAs
+export interface ToolSchema {
+  id: string;
+  description: string;
+  activationPhrases?: string[];
+  parameters?: Record<string, ToolParameterSchema>;
+}
+
 /**
  * Developer profile information
  */

--- a/augmentos_docs/docs/getting-started.md
+++ b/augmentos_docs/docs/getting-started.md
@@ -224,6 +224,12 @@ ngrok http --url=<YOUR_NGROK_URL_HERE> 3000
 
 > **IMPORTANT:** After making changes to your app code or restarting your server, you must restart your app inside the AugmentOS phone app.
 
+## Part 4: Setting Up TPA AI Tools for Mira
+
+Mira, the AugmentOS AI assistant, can call functions in your TPA. This allows your application to extend Mira's capabilities with custom tools.
+
+For a comprehensive guide on TPA AI tools, see [AI Tools](/tools).
+
 ## What's Next?
 
 Congratulations! You've built your first AugmentOS app. To continue your journey:

--- a/augmentos_docs/docs/reference/interfaces/tool-types.md
+++ b/augmentos_docs/docs/reference/interfaces/tool-types.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 5
+title: Tool Types
+---
+
+# Tool Types
+
+This page documents the interfaces and types used for TPA tools integration with Mira AI.
+
+For a complete guide on implementing TPA tools, see [AI Tools](/tools).
+
+## ToolSchema
+
+Interface defining the structure of a tool that a TPA can expose to Mira AI.
+
+```typescript
+interface ToolSchema {
+  /** Unique identifier for the tool */
+  id: string;
+  
+  /** Human-readable description of what the tool does */
+  description: string;
+  
+  /** Optional phrases that might trigger this tool (helps Mira recognize when to use it) */
+  activationPhrases?: string[];
+  
+  /** Definition of parameters this tool accepts */
+  parameters?: Record<string, ToolParameterSchema>;
+}
+```
+
+## ToolParameterSchema
+
+Interface defining the structure of parameters that a tool accepts.
+
+```typescript
+interface ToolParameterSchema {
+  /** Data type of the parameter */
+  type: 'string' | 'number' | 'boolean';
+  
+  /** Human-readable description of what the parameter is for */
+  description: string;
+  
+  /** Optional list of allowed values for string parameters */
+  enum?: string[];
+  
+  /** Whether this parameter is required */
+  required?: boolean;
+}
+```
+
+## ToolCall
+
+Interface representing a call to a TPA tool from Mira AI.
+
+```typescript
+interface ToolCall {
+  /** ID of the tool being called */
+  toolId: string;
+  
+  /** Parameter values for this specific call */
+  toolParameters: Record<string, string | number | boolean>;
+  
+  /** When the tool call was made */
+  timestamp: Date;
+  
+  /** ID of the user who triggered the tool call */
+  userId: string;
+}
+```
+
+## Tool Configuration
+
+TPAs define their tools in a `tpa_config.json` file at the root of their server's public directory. Example:
+
+```json
+{
+  "name": "Todo App",
+  "description": "Manage your to-do items",
+  "version": "1.0.0",
+  "tools": [
+    {
+      "id": "add_todo",
+      "description": "Add a new to-do item",
+      "activationPhrases": ["add a reminder", "create a todo", "remind me to"],
+      "parameters": {
+        "todo_item": {
+          "type": "string",
+          "description": "The to-do item text",
+          "required": true
+        },
+        "due_date": {
+          "type": "string",
+          "description": "Due date in ISO format (YYYY-MM-DD)"
+        }
+      }
+    },
+    {
+      "id": "get_todos",
+      "description": "Get all to-do items",
+      "activationPhrases": ["show my todos", "list my reminders"],
+      "parameters": {
+        "include_completed": {
+          "type": "boolean",
+          "description": "Whether to include completed items",
+          "required": false
+        }
+      }
+    }
+  ]
+}
+``` 

--- a/augmentos_docs/docs/reference/tpa-server.md
+++ b/augmentos_docs/docs/reference/tpa-server.md
@@ -70,6 +70,47 @@ protected onStop(
 
 **Returns:** A Promise that resolves when session cleanup is complete
 
+### onToolCall() _[protected]_
+
+Override this method to handle tool calls from Mira AI. This is where you implement your app's tool functionality.
+
+For a comprehensive guide on implementing AI tools, see [AI Tools](/tools).
+
+```typescript
+protected onToolCall(
+  toolCall: ToolCall
+): Promise<string | undefined>
+```
+
+**Parameters:**
+- `toolCall`: A [ToolCall](/reference/interfaces/tool-types#toolcall) object containing the tool ID, parameters, user ID, and timestamp
+
+**Returns:** A Promise that resolves to an optional string response that will be sent back to Mira
+
+**Example:**
+```typescript
+protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
+  console.log(`Tool called: ${toolCall.toolId}`);
+  console.log(`Tool call timestamp: ${toolCall.timestamp}`);
+  console.log(`Tool call userId: ${toolCall.userId}`);
+  
+  if (toolCall.toolParameters && Object.keys(toolCall.toolParameters).length > 0) {
+    console.log("Tool call parameter values:", toolCall.toolParameters);
+  }
+
+  if (toolCall.toolId === "add_todo") {
+    const reminder = addReminder(
+      toolCall.userId, 
+      toolCall.toolParameters.todo_item as string, 
+      toolCall.toolParameters.due_date as string | undefined
+    );
+    return `Added reminder: ${reminder.text}`;
+  }
+
+  return undefined;
+}
+```
+
 ### start()
 
 Starts the TPA server, making it listen for incoming webhook requests.

--- a/augmentos_docs/docs/tools.md
+++ b/augmentos_docs/docs/tools.md
@@ -1,0 +1,406 @@
+# AI Tools
+
+*Last updated: August 3, 2023*
+
+AugmentOS provides a powerful way for TPAs to extend Mira AI's capabilities through custom tools. These tools allow Mira to take actions within your TPA, such as creating content, fetching data, or controlling features - all through natural language conversations with users.
+
+```typescript
+// Example of handling a tool call in your TPA
+protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
+  if (toolCall.toolId === "add_todo") {
+    const todoItem = toolCall.toolParameters.todo_item as string;
+    const dueDate = toolCall.toolParameters.due_date as string | undefined;
+    
+    // Add the todo item to your storage
+    const newTodo = await this.todoService.addTodo(toolCall.userId, todoItem, dueDate);
+    
+    return `✅ Added: "${todoItem}"${dueDate ? ` due ${dueDate}` : ''}`;
+  }
+  
+  return undefined;
+}
+```
+
+## What Are TPA Tools?
+
+TPA tools are functions that your application exposes to Mira AI. When a user asks Mira to perform an action that matches one of your tools, Mira will:
+
+1. Identify the relevant tool
+2. Extract necessary parameters from the user's request 
+3. Call your TPA with these parameters
+4. Return your response to the user
+
+This creates a seamless experience where users interact with your TPA through natural conversations with Mira.
+
+Tool calls don't happen in the context of a session, and your app does not need to be running to respond to a tool call.  Your app should respond with a text string that Mira's AI will use to formulate a response.
+
+For detailed reference on the interfaces involved, see [Tool Types](/reference/interfaces/tool-types).
+
+## Defining Your Tools
+
+Tools are defined in a `tpa_config.json` file placed in your TPA's public directory. This file describes your tools, their parameters, and phrases that might trigger them.
+
+### Basic Structure
+
+```json
+{
+  "name": "My TPA",
+  "description": "My awesome TPA description",
+  "version": "1.0.0",
+  "tools": [
+    {
+      "id": "tool_id",
+      "description": "What this tool does",
+      "activationPhrases": ["add something", "create new", "make a"],
+      "parameters": {
+        "param_name": {
+          "type": "string",
+          "description": "What this parameter does",
+          "required": true
+        }
+      }
+    }
+  ]
+}
+```
+
+### Tool Properties
+
+Each tool definition requires:
+
+* **`id`**: Unique identifier for the tool (string)
+* **`description`**: Human-readable description of what the tool does (string)
+* **`activationPhrases`**: Optional array of phrases that might trigger this tool (array of strings, optional)
+* **`parameters`**: Optional map of parameters the tool accepts (object, optional)
+
+For the full interface definition, see [ToolSchema](/reference/interfaces/tool-types#toolschema).
+
+### Parameter Properties
+
+Each parameter definition requires:
+
+* **`type`**: Data type of the parameter - `"string"`, `"number"`, or `"boolean"`
+* **`description`**: Human-readable description of the parameter
+* **`required`**: Whether the parameter is required (boolean, default: false)
+* **`enum`**: Optional array of allowed values for string parameters (optional)
+
+For the full interface definition, see [ToolParameterSchema](/reference/interfaces/tool-types#toolparameterschema).
+
+## Implementing Tool Handling
+
+### 1. Override onToolCall
+
+In your TPA server, override the [`onToolCall`](/reference/tpa-server#ontoolcall-protected) method to handle incoming tool calls:
+
+```typescript
+import { TpaServer, ToolCall } from '@augmentos/sdk';
+
+export class MyTpaServer extends TpaServer {
+  protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
+    console.log(`Tool called: ${toolCall.toolId}`);
+    console.log(`User: ${toolCall.userId}`);
+    console.log(`Parameters: ${JSON.stringify(toolCall.toolParameters)}`);
+    
+    // Handle specific tools based on toolId
+    switch (toolCall.toolId) {
+      case 'my_tool':
+        return this.handleMyTool(toolCall);
+      case 'another_tool':
+        return this.handleAnotherTool(toolCall);
+      default:
+        return undefined;
+    }
+  }
+  
+  private async handleMyTool(toolCall: ToolCall): Promise<string> {
+    // Implement your tool-specific logic here
+    // ...
+    return "Tool result message";
+  }
+}
+```
+
+### 2. The ToolCall Interface
+
+The `ToolCall` object contains:
+
+```typescript
+interface ToolCall {
+  /** ID of the tool being called */
+  toolId: string;
+  
+  /** Parameter values extracted by Mira */
+  toolParameters: Record<string, string | number | boolean>;
+  
+  /** When the tool call was made */
+  timestamp: Date;
+  
+  /** ID of the user who triggered the tool */
+  userId: string;
+}
+```
+
+See the full definition at [ToolCall](/reference/interfaces/tool-types#toolcall).
+
+### 3. Return Values
+
+Your `onToolCall` method should return:
+
+* A **string** - Displayed to the user as Mira's response
+* **undefined** - If the tool can't handle the request (Mira will inform the user)
+
+## Common Tool Patterns
+
+### CRUD Operations
+
+```json
+{
+  "tools": [
+    {
+      "id": "create_item",
+      "description": "Create a new item",
+      "parameters": {
+        "name": {
+          "type": "string",
+          "description": "Name of the item",
+          "required": true
+        },
+        "category": {
+          "type": "string",
+          "description": "Category of the item",
+          "enum": ["Category1", "Category2", "Category3"]
+        }
+      }
+    },
+    {
+      "id": "get_items",
+      "description": "Get a list of items",
+      "parameters": {
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of items to return"
+        },
+        "category": {
+          "type": "string",
+          "description": "Filter by category"
+        }
+      }
+    },
+    {
+      "id": "update_item",
+      "description": "Update an existing item",
+      "parameters": {
+        "id": {
+          "type": "string",
+          "description": "ID of the item to update",
+          "required": true
+        },
+        "name": {
+          "type": "string",
+          "description": "New name for the item"
+        },
+        "category": {
+          "type": "string",
+          "description": "New category for the item"
+        }
+      }
+    },
+    {
+      "id": "delete_item",
+      "description": "Delete an item",
+      "parameters": {
+        "id": {
+          "type": "string",
+          "description": "ID of the item to delete",
+          "required": true
+        }
+      }
+    }
+  ]
+}
+```
+
+### Todo List Example
+
+```json
+{
+  "tools": [
+    {
+      "id": "add_todo",
+      "description": "Add a new to-do item",
+      "activationPhrases": ["add a reminder", "create a todo", "remind me to"],
+      "parameters": {
+        "todo_item": {
+          "type": "string",
+          "description": "The to-do item text",
+          "required": true
+        },
+        "due_date": {
+          "type": "string",
+          "description": "Due date in ISO format (YYYY-MM-DD)"
+        }
+      }
+    },
+    {
+      "id": "get_todos",
+      "description": "Get all to-do items",
+      "activationPhrases": ["show my todos", "list my reminders"],
+      "parameters": {
+        "include_completed": {
+          "type": "boolean",
+          "description": "Whether to include completed items"
+        }
+      }
+    },
+    {
+      "id": "mark_todo_complete",
+      "description": "Mark a to-do item as complete",
+      "parameters": {
+        "todo_id": {
+          "type": "string",
+          "description": "ID of the to-do item",
+          "required": true
+        }
+      }
+    }
+  ]
+}
+```
+
+## Implementation Example
+
+Here's how to implement a complete todo list TPA with Mira integration:
+
+```typescript
+import { TpaServer, ToolCall } from '@augmentos/sdk';
+
+// Simple in-memory todo storage
+const todos = new Map<string, Map<string, Todo>>();
+
+interface Todo {
+  id: string;
+  text: string;
+  completed: boolean;
+  dueDate?: string;
+  createdAt: Date;
+}
+
+export class TodoTpaServer extends TpaServer {
+  protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
+    const { toolId, userId, toolParameters } = toolCall;
+    
+    // Initialize user's todo list if it doesn't exist
+    if (!todos.has(userId)) {
+      todos.set(userId, new Map<string, Todo>());
+    }
+    
+    // Get user's todo list
+    const userTodos = todos.get(userId)!;
+    
+    // Handle different tool calls
+    switch (toolId) {
+      case 'add_todo': {
+        const todoText = toolParameters.todo_item as string;
+        const dueDate = toolParameters.due_date as string | undefined;
+        
+        // Create a new todo
+        const id = Date.now().toString();
+        const newTodo: Todo = {
+          id,
+          text: todoText,
+          completed: false,
+          dueDate,
+          createdAt: new Date()
+        };
+        
+        // Save it
+        userTodos.set(id, newTodo);
+        
+        return `✅ Added to your list: "${todoText}"${dueDate ? ` due ${dueDate}` : ''}`;
+      }
+      
+      case 'get_todos': {
+        const includeCompleted = toolParameters.include_completed as boolean || false;
+        
+        // Filter todos
+        const filteredTodos = Array.from(userTodos.values())
+          .filter(todo => includeCompleted || !todo.completed)
+          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+        
+        if (filteredTodos.length === 0) {
+          return "You don't have any todos yet.";
+        }
+        
+        // Format response
+        const todoList = filteredTodos.map(todo => 
+          `- ${todo.completed ? '✓' : '○'} ${todo.text}${todo.dueDate ? ` (due ${todo.dueDate})` : ''}`
+        ).join('\n');
+        
+        return `Your todo list:\n${todoList}`;
+      }
+      
+      case 'mark_todo_complete': {
+        const todoId = toolParameters.todo_id as string;
+        const todo = userTodos.get(todoId);
+        
+        if (!todo) {
+          return "I couldn't find that todo item.";
+        }
+        
+        // Update todo
+        todo.completed = true;
+        userTodos.set(todoId, todo);
+        
+        return `✓ Marked "${todo.text}" as complete.`;
+      }
+      
+      case 'mark_todo_incomplete': {
+        const todoId = toolParameters.todo_id as string;
+        const todo = userTodos.get(todoId);
+        
+        if (!todo) {
+          return "I couldn't find that todo item.";
+        }
+        
+        // Update todo
+        todo.completed = false;
+        userTodos.set(todoId, todo);
+        
+        return `○ Marked "${todo.text}" as incomplete.`;
+      }
+      
+      case 'delete_todo': {
+        const todoId = toolParameters.todo_id as string;
+        const todo = userTodos.get(todoId);
+        
+        if (!todo) {
+          return "I couldn't find that todo item.";
+        }
+        
+        // Delete todo
+        userTodos.delete(todoId);
+        
+        return `🗑️ Deleted "${todo.text}" from your list.`;
+      }
+      
+      default:
+        return undefined;
+    }
+  }
+}
+```
+
+## Tool Call Lifecycle
+
+1. **Tool Call Detection**: Mira AI identifies a tool call based on the tool's activation phrases
+2. **Parameter Extraction**: Mira extracts parameters from the user's request
+3. **Tool Call Execution**: Mira calls the `/tool` endpoint of your TPA server with the extracted parameters.  You don't need to handle this manually, the SDK handles this for you.
+4. **Your TPA Handles the Tool Call**: Your overridden `onToolCall` method is called with the tool call details.  You can handle the tool call logic here.
+5. **Your TPA Responds**: Your app responds with a text string that Mira's AI will use to formulate a response.
+6. **Mira Responds to the User**: Mira uses your response to formulate a response to the user, or call other tools as needed.  Your response is not necessarily the final response to the user, it is just information the AI uses to formulate a response.
+
+## Related Documentation
+
+* [Tool Types Reference](/reference/interfaces/tool-types) - Detailed type definitions for tools
+* [TPA Server - onToolCall](/reference/tpa-server#ontoolcall-protected) - API reference for the onToolCall method
+* [Getting Started with TPAs](/getting-started) - Complete guide to building a TPA

--- a/augmentos_docs/sidebars.ts
+++ b/augmentos_docs/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'events',
         'layouts',
+        'tools',
         {
           type: 'doc',
           id: 'tpa-lifecycle',
@@ -67,6 +68,7 @@ const sidebars: SidebarsConfig = {
             'reference/interfaces/layout-types',
             'reference/interfaces/webhook-types',
             'reference/interfaces/message-types',
+            'reference/interfaces/tool-types',
           ],
         },
         'reference/token-utils',


### PR DESCRIPTION
Allow Third-Party Applications (TPAs) to define tools for use by Mira AI
Closes #365 

Introduces a system where TPAs can define specific tools, activation phrases, and parameters in their `tpa_config.json` file.

**Mira AI Activation (Webhook):**
The Mira AI assistant will be able to discover TPA tools via a new Cloud API. Mira presents these commands as tools to the AI. When Mira's AI decides to call a tool, Mira will send an HTTP POST request (webhook) to the TPA's `/command` endpoint with the command ID and parameters. The TPA will handle this request and can return a response.

**Key Features & Requirements:**

*   **Tool Definition:** Extend `tpa_config.json` schema to include a `tools` array, defining command `id`, `description`, `activationPhrases`, and `parameters` (with `key`, `description`, `type`, `required`).
*   **Cloud Service Logic:**
    *   Parse and store tool definitions from TPA configurations.
    *   Implement logic to trigger TPA `/tool` webhooks securely.
    *   Expose a Cloud API (`GET /api/apps/{packageName}/tools`) for Mira to discover TPA commands.
*   **SDK Enhancements (`@augmentos/sdk`):**
    *   Update `TpaServer` to automatically register a `POST /tool` webhook endpoint.
    *   Implement auth verification within the default `/tool` handler.

**Update to the Mira app**
The Mira app has a PR which makes it actually use this: https://github.com/AugmentOS-Community/Mira/pull/2
That Mira PR should not be merged until after this PR is merged and running in prod!

**Demo Video**
Here's a demo video of this working:
https://youtube.com/shorts/PsOMZ-YKLrI?feature=share

**Example command definition:**

```json
{
  "name": "My Awesome App",
  "description": "A demo app to show tool calling",
  "version": "1.0.0",
  "settings": [
    // ... existing settings ...
  ],
  "tools": [
    {
      "id": "add_note",
      "description": "Adds a new note with the spoken text.",
      "activationPhrases": [
        "add note",
        "take a note",
        "create note"
      ],
      "parameters": {
        "note_content": {
          "type": "string",
          "description": "The content of the note to be saved.",
          "required": true
        }
        
      }
    },
    {
      "id": "set_timer",
      "description": "Sets a timer for a specified duration.",
      "activationPhrases": [
        "set timer for",
        "start timer",
        "timer"
      ],
      "parameters": {
        "duration": {
          "type": "number",
          "description": "The duration of the timer in minutes.",
          "required": true
        },
        "timer_label": {
          "type": "string",
          "description": "An optional label for the timer.",
          "required": false
        }
      }
    },
    {
      "id": "get_weather",
      "description": "Retrieves current weather for the given location.",
      "activationPhrases": [
        "what's the weather in",
        "weather in",
        "get weather"
      ],
      "parameters": {
        "location": {
          "type": "string",
            "description": "City and country e.g. Bogotá, Colombia",
            "required": true
          },
        "units": {
          "type": "string",
          "enum": [
            "celsius",
            "fahrenheit"
          ],
          "description": "Units the temperature will be returned in.",
          "required": true
        }  
      }
    }
    // ... other commands ...
  ]
}
```