### PR TITLE
Fix store login redirect

### DIFF
--- a/augmentos_cloud/store/web/src/hooks/useAuth.tsx
+++ b/augmentos_cloud/store/web/src/hooks/useAuth.tsx
@@ -252,12 +252,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             // Check if we're on the login page and need to redirect
             const isLoginPage = window.location.pathname.includes('/login') || 
                               window.location.pathname.includes('/signin');
-            
-            if (isLoginPage) {
-              // Get redirect path from URL or storage
-              const urlParams = new URLSearchParams(window.location.search);
-              const redirectTo = urlParams.get('redirectTo') || localStorage.getItem('auth_redirect') || '/';
-              
+            const localRedirect = localStorage.getItem('auth_redirect');
+            const urlParams = new URLSearchParams(window.location.search);
+            const redirectToFromURLParams = urlParams.get('redirectTo');
+            if (isLoginPage || localRedirect || redirectToFromURLParams) {
+              console.log(`isLoginPage: ${isLoginPage}`);
+              console.log(`localRedirect: ${localRedirect}`);
+              console.log(`redirectToFromURLParams: ${redirectToFromURLParams}`);
+              const redirectTo = redirectToFromURLParams || localRedirect || '/';
               console.log('Redirecting to:', redirectTo);
               // Clear storage
               localStorage.removeItem('auth_redirect');

--- a/augmentos_cloud/store/web/src/pages/AppDetails.tsx
+++ b/augmentos_cloud/store/web/src/pages/AppDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation  } from 'react-router-dom';
 import { ArrowLeft, Download, X, ExternalLink, Calendar, Clock, Info, Star, Package, Building, Globe, Mail, FileText } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import api from '../api';
@@ -251,7 +251,7 @@ const AppDetails: React.FC = () => {
                         )
                       ) : (
                         <Button
-                          onClick={() => navigate('/login')}
+                          onClick={() => navigate('/login', { state: { returnTo: location.pathname } })}
                           className="bg-blue-600 hover:bg-blue-700 w-full md:w-48"
                         >
                           Sign in to install


### PR DESCRIPTION
Previously, when viewing a app detail page in the store when not logged in, after logging in you would get redirected to the store landing page rather than the detail page. This fixes that.