### PR TITLE
added builder service for reliable docker builds

### DIFF
--- a/augmentos_cloud/docker-compose.dev.yml
+++ b/augmentos_cloud/docker-compose.dev.yml
@@ -1,4 +1,21 @@
 services:
+  # this new service will run first. it installs dependencies and builds the shared packages
+  # that other services like 'cloud' and 'dashboard-manager' need to run.
+  builder:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./:/app
+      - node_modules:/app/node_modules
+      - bun_cache:/root/.bun
+    # this command installs everything and then builds the shared packages one by one
+    command: >
+      bash -c "bun install && 
+      cd packages/sdk && bun run build && cd ../.. &&
+      cd packages/utils && bun run build && cd ../.. &&
+      cd packages/agents && bun run build"
+
   # Cloud service
   cloud:
     stop_grace_period: 10s
@@ -28,9 +45,12 @@ services:
       - ./:/app
       - node_modules:/app/node_modules
       - bun_cache:/root/.bun
-    command: bash -c "bun install && cd packages/cloud && bun run dev"
+    command: bash -c "cd packages/cloud && bun run dev"
     networks:
       - augmentos-network-dev
+    depends_on:
+      builder:
+        condition: service_completed_successfully
 
   # Dashboard service
   dashboard-manager:
@@ -56,6 +76,9 @@ services:
     command: bash -c "cd packages/apps/dashboard && bun run dev"
     networks:
       - augmentos-network-dev
+    depends_on:
+      builder:
+        condition: service_completed_successfully
     # depends_on:
       # shared-packages:
       #   condition: service_healthy


### PR DESCRIPTION
Running "bun run dev" gave me a "cannot find module error" when I set up dev environment for the first time. I found that this was because services like cloud and dashboard-manager depend on shared local packages (e.g., @augmentos/utils, @augmentos/sdk) and the cloud service would try to start before its dependencies were fully built and available within the Docker container. 

This pr introduces a dedicated builder service whose only responsibility is to prepare the environment. It runs bun install to correctly link all workspaces and then builds the shared packages (sdk, utils, agents) in order. Updated the cloud and dashboard-manager services to have a "depends_on" condition so that they'll now explicitly wait for the builder service to exit with a service_completed_successfully status before they attempt to start.

I think this will improve the developer experience by providing a reliable setup for new contributors and it will also hopefully simplify future maintenance because it centralizes the build logic