### PR TITLE
added faster gps functionality for iOS

### DIFF
--- a/augmentos_cloud/docker-compose.dev.yml
+++ b/augmentos_cloud/docker-compose.dev.yml
@@ -1,4 +1,21 @@
 services:
+  # this new service will run first. it installs dependencies and builds the shared packages
+  # that other services like 'cloud' and 'dashboard-manager' need to run.
+  builder:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./:/app
+      - node_modules:/app/node_modules
+      - bun_cache:/root/.bun
+    # this command installs everything and then builds the shared packages one by one
+    command: >
+      bash -c "bun install && 
+      cd packages/sdk && bun run build && cd ../.. &&
+      cd packages/utils && bun run build && cd ../.. &&
+      cd packages/agents && bun run build"
+
   # Cloud service
   cloud:
     stop_grace_period: 10s
@@ -28,9 +45,12 @@ services:
       - ./:/app
       - node_modules:/app/node_modules
       - bun_cache:/root/.bun
-    command: bash -c "bun install && cd packages/cloud && bun run dev"
+    command: bash -c "cd packages/cloud && bun run dev"
     networks:
       - augmentos-network-dev
+    depends_on:
+      builder:
+        condition: service_completed_successfully
 
   # Dashboard service
   dashboard-manager:
@@ -56,6 +76,9 @@ services:
     command: bash -c "cd packages/apps/dashboard && bun run dev"
     networks:
       - augmentos-network-dev
+    depends_on:
+      builder:
+        condition: service_completed_successfully
     # depends_on:
       # shared-packages:
       #   condition: service_healthy

--- a/augmentos_manager/ios/BleManager/LocationManager.swift
+++ b/augmentos_manager/ios/BleManager/LocationManager.swift
@@ -30,6 +30,22 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     
     // Start location updates (will only work if permission is already granted)
     locationManager.startUpdatingLocation()
+
+  }
+  
+  // Enables highest-accuracy gps mode (higher battery consumption so we'll need to
+  // disclose that in the SDK docs. TPA's should not use this unless they have a great reason)
+  // The distanceFilter can be changed for kCLLocationAccuracyBestForNavigation as well
+  public func setHighAccuracyMode(enabled: Bool) {
+    if enabled {
+      print("LocationManager: enabling high accuracy mode")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+      locationManager.distanceFilter = kCLDistanceFilterNone
+    } else {
+      print("LocationManager: disabling high accuracy mode")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      locationManager.distanceFilter = 2 // back to the default 2 meters
+    }
   }
   
   func setLocationChangedCallback(_ callback: @escaping () -> Void) {


### PR DESCRIPTION
Hey guys! This is a first step for getting adjustable location rates working in the future.

This pr just adds a new function to the iOS LocationManager.swift called 'setHighAccuracyMode(enabled: Bool)'. When you set it to true, it changes the accuracy to 'kCLLocationAccuracyBestForNavigation' instead of 'kCLLocationAccuracyBest' and removes the distance filter, which makes the location updates faster.

kCLLocationAccuracyBestForNavigation is Apple's own constant for the highest quality location stream you can get from the OS and is designed for things like turn by turn navigation. This would let us give TPA devs the option to have variable location stream options based on the TPA's location needs.

It's a non-breaking change because the new function isn't called anywhere yet.

If we continued to work on this:
- same thing would need to be done for Android
- expose both the iOS and Android functions over the react native bridge
- hook it into the cloud and SDK so a dev can choose to enable it when they subscribe to location updates

Just a heads up, this high accuracy mode will definitely use significantly more battery so we'll have to disclose that in the docs if we went forward with this feature.

Here's the apple doc on this 'kCLLocationAccuracyBestForNavigation' accuracy setting:
https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation

Let me know if this is something you guys would want want me to keep exploring or if there's any adjustments you'd like!