### PR TITLE
added high accuracy GPS function for ios

### DIFF
--- a/augmentos_manager/ios/BleManager/LocationManager.swift
+++ b/augmentos_manager/ios/BleManager/LocationManager.swift
@@ -30,6 +30,22 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     
     // Start location updates (will only work if permission is already granted)
     locationManager.startUpdatingLocation()
+
+  }
+  
+  // enables highest-accuracy gps mode (higher battery consumption so we'll need to
+  // disclose that in the SDK docs)
+  // The distanceFilter can be changed for kCLLocationAccuracyBestForNavigation as well
+  public func setHighAccuracyMode(enabled: Bool) {
+    if enabled {
+      print("LocationManager: enabling high accuracy mode")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+      locationManager.distanceFilter = kCLDistanceFilterNone
+    } else {
+      print("LocationManager: disabling high accuracy mode")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      locationManager.distanceFilter = 2 // back to the default 2 meters
+    }
   }
   
   func setLocationChangedCallback(_ callback: @escaping () -> Void) {


### PR DESCRIPTION
Hi guys, this is a first step for getting adjustable location rates working in the future.

This pr just adds a new function to the iOS LocationManager.swift called 'setHighAccuracyMode(enabled: Bool)'. When you set it to true, it changes the accuracy to 'kCLLocationAccuracyBestForNavigation' instead of 'kCLLocationAccuracyBest' and removes the distance filter, which makes the location updates faster.

kCLLocationAccuracyBestForNavigation is Apple's own constant for the highest quality location stream you can get and is designed for things like turn by turn navigation. This would let us give TPA devs the option to have variable location stream options based on the TPA's location needs.

It's a non-breaking change because the new function isn't called anywhere yet.

If we continued to work on this:

- same thing would need to be done for Android
- expose both the iOS and Android functions over the react native bridge
- hook it into the cloud and SDK so a dev can choose to enable it when they subscribe to location updates

This high accuracy mode will definitely use significantly more battery so we'd have to disclose that in the docs if we went forward with this feature.

Here's the apple doc on this 'kCLLocationAccuracyBestForNavigation' accuracy setting:
https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation

Let me know if this is something you guys would want want me to keep working on or if there's any adjustments you'd like!