### PR TITLE
Location module

### DIFF
--- a/augmentos_cloud/packages/sdk/src/tpa/session/index.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/session/index.ts
@@ -1361,9 +1361,10 @@ export class TpaSession {
     const subscriptionPayload: SubscriptionRequest[] = Array.from(this.subscriptions).map(stream => {
       const rate = this.streamRates.get(stream);
       if (rate && stream === StreamType.LOCATION_STREAM) {
-        return { stream: 'location_stream', rate: rate as any };
+        // We know rate is a valid string from our previous checks but ts needs assurance
+        return { stream: 'location_stream', rate: rate as 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' };
       }
-      return stream;
+      return stream; // Return the string if no rate is associated
     });
 
     const message: TpaSubscriptionUpdate = {

--- a/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
@@ -6,12 +6,12 @@ export class LocationManager {
 
   public subscribeToStream(options: { accuracy: 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }): void {
     const subscription = { stream: StreamType.LOCATION_STREAM, rate: options.accuracy };
-    // @ts-ignore - This will be fixed when we update the TpaSession subscribe method
+    // @ts-ignore - I'll fix this when I update the TpaSession subscribe method
     this.session.subscribe(subscription);
   }
 
   public unsubscribeFromStream(): void {
-    // @ts-ignore - This will be fixed when we update the TpaSession unsubscribe method
+    // @ts-ignore - This will also be fixed when I update the TpaSession unsubscribe method
     this.session.unsubscribe({ stream: StreamType.LOCATION_STREAM });
   }
   
@@ -23,6 +23,7 @@ export class LocationManager {
       // @ts-ignore
       const unsubscribe = this.session.events.on('location_update', (data: LocationUpdate) => {
         // @ts-ignore - correlationId will be added to the LocationUpdate type later
+        // every time a location update arrives, we check if it has a correlationId that matches the requestId we just created.
         if (data.correlationId === requestId) {
           unsubscribe(); // Stop listening once we get our response
           resolve(data);

--- a/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
@@ -1,18 +1,16 @@
 import { TpaSession } from '..';
-import { StreamType, TpaToCloudMessageType, LocationUpdate } from '../../../types';
+import { StreamType, TpaToCloudMessageType, LocationUpdate, LocationStreamRequest } from '../../../types';
 
 export class LocationManager {
   constructor(private session: TpaSession, private send: (message: any) => void) {}
 
   public subscribeToStream(options: { accuracy: 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }): void {
-    const subscription = { stream: StreamType.LOCATION_STREAM, rate: options.accuracy };
-    // @ts-ignore - I'll fix this when I update the TpaSession subscribe method
+    const subscription: LocationStreamRequest = { stream: 'location_stream', rate: options.accuracy };
     this.session.subscribe(subscription);
   }
 
   public unsubscribeFromStream(): void {
-    // @ts-ignore - This will also be fixed when I update the TpaSession unsubscribe method
-    this.session.unsubscribe({ stream: StreamType.LOCATION_STREAM });
+    this.session.unsubscribe('location_stream');
   }
   
   public async getLatestLocation(options: { accuracy: string }): Promise<LocationUpdate> {

--- a/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
@@ -1,0 +1,46 @@
+import { TpaSession } from '..';
+import { StreamType, TpaToCloudMessageType, LocationUpdate } from '../../../types';
+
+export class LocationManager {
+  constructor(private session: TpaSession, private send: (message: any) => void) {}
+
+  public subscribeToStream(options: { accuracy: 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }): void {
+    const subscription = { stream: StreamType.LOCATION_STREAM, rate: options.accuracy };
+    // @ts-ignore - This will be fixed when we update the TpaSession subscribe method
+    this.session.subscribe(subscription);
+  }
+
+  public unsubscribeFromStream(): void {
+    // @ts-ignore - This will be fixed when we update the TpaSession unsubscribe method
+    this.session.unsubscribe({ stream: StreamType.LOCATION_STREAM });
+  }
+  
+  public async getLatestLocation(options: { accuracy: string }): Promise<LocationUpdate> {
+    return new Promise((resolve, reject) => {
+      const requestId = `poll_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      
+      // Listen for the specific response
+      // @ts-ignore
+      const unsubscribe = this.session.events.on('location_update', (data: LocationUpdate) => {
+        // @ts-ignore - correlationId will be added to the LocationUpdate type later
+        if (data.correlationId === requestId) {
+          unsubscribe(); // Stop listening once we get our response
+          resolve(data);
+        }
+      });
+
+      // Send the poll request message to the cloud
+      this.send({
+        type: TpaToCloudMessageType.LOCATION_POLL_REQUEST,
+        correlationId: requestId,
+        payload: { accuracy: options.accuracy }
+      });
+
+      // Timeout to prevent hanging promises
+      setTimeout(() => {
+        unsubscribe();
+        reject(new Error('Location poll request timed out.'));
+      }, 15000); // 15 second timeout
+    });
+  }
+} 

--- a/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
+++ b/augmentos_cloud/packages/sdk/src/tpa/session/modules/location.ts
@@ -18,7 +18,6 @@ export class LocationManager {
       const requestId = `poll_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
       
       // Listen for the specific response
-      // @ts-ignore
       const unsubscribe = this.session.events.on('location_update', (data: LocationUpdate) => {
         // @ts-ignore - correlationId will be added to the LocationUpdate type later
         // every time a location update arrives, we check if it has a correlationId that matches the requestId we just created.

--- a/augmentos_cloud/packages/sdk/src/types/message-types.ts
+++ b/augmentos_cloud/packages/sdk/src/types/message-types.ts
@@ -87,6 +87,7 @@ export enum TpaToCloudMessageType {
   // Commands
   CONNECTION_INIT = 'tpa_connection_init',
   SUBSCRIPTION_UPDATE = 'subscription_update',
+  LOCATION_POLL_REQUEST = 'location_poll_request',
 
   // Requests
   DISPLAY_REQUEST = 'display_event',

--- a/augmentos_cloud/packages/sdk/src/types/messages/tpa-to-cloud.ts
+++ b/augmentos_cloud/packages/sdk/src/types/messages/tpa-to-cloud.ts
@@ -7,6 +7,17 @@ import { DisplayRequest } from '../layouts';
 import { DashboardContentUpdate, DashboardModeChange, DashboardSystemUpdate } from '../dashboard';
 import { VideoConfig, AudioConfig, StreamConfig } from '../rtmp-stream';
 
+// [NEW TYPE DEFINITION]
+// Defines a specific object for our tiered location stream requests.
+export interface LocationStreamRequest {
+  stream: 'location_stream';
+  rate: 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+}
+
+// [UPDATED TYPE DEFINITION]
+// A subscription can now be a generic stream type OR our specific location request object.
+export type SubscriptionRequest = ExtendedStreamType | LocationStreamRequest;
+
 /**
  * Connection initialization from TPA
  */
@@ -23,7 +34,7 @@ export interface TpaConnectionInit extends BaseMessage {
 export interface TpaSubscriptionUpdate extends BaseMessage {
   type: TpaToCloudMessageType.SUBSCRIPTION_UPDATE;
   packageName: string;
-  subscriptions: ExtendedStreamType[];
+  subscriptions: SubscriptionRequest[];
 }
 
 /**
@@ -58,12 +69,21 @@ export interface RtmpStreamStopRequest extends BaseMessage {
   streamId?: string;  // Optional stream ID to specify which stream to stop
 }
 
+// Interface for location poll request from TPA
+export interface TpaLocationPollRequest extends BaseMessage {
+  type: TpaToCloudMessageType.LOCATION_POLL_REQUEST;
+  packageName: string;
+  sessionId: string;
+  accuracy: string;
+}
+
 /**
  * Union type for all messages from TPAs to cloud
  */
 export type TpaToCloudMessage =
   | TpaConnectionInit
   | TpaSubscriptionUpdate
+  | TpaLocationPollRequest
   | DisplayRequest
   | PhotoRequest
   | RtmpStreamRequest

--- a/augmentos_cloud/packages/sdk/src/types/streams.ts
+++ b/augmentos_cloud/packages/sdk/src/types/streams.ts
@@ -14,6 +14,7 @@ export enum StreamType {
   PHONE_BATTERY_UPDATE = 'phone_battery_update',
   GLASSES_CONNECTION_STATE = 'glasses_connection_state',
   LOCATION_UPDATE = 'location_update',
+  LOCATION_STREAM = 'location_stream',
   VPS_COORDINATES = 'vps_coordinates',
   
   // Audio streams
@@ -82,6 +83,7 @@ export const STREAM_CATEGORIES: Record<StreamType, StreamCategory> = {
   [StreamType.PHONE_BATTERY_UPDATE]: StreamCategory.HARDWARE,
   [StreamType.GLASSES_CONNECTION_STATE]: StreamCategory.HARDWARE,
   [StreamType.LOCATION_UPDATE]: StreamCategory.HARDWARE,
+  [StreamType.LOCATION_STREAM]: StreamCategory.HARDWARE,
   [StreamType.VPS_COORDINATES]: StreamCategory.HARDWARE,
   
   [StreamType.TRANSCRIPTION]: StreamCategory.AUDIO,

--- a/augmentos_cloud/packages/sdk/src/types/streams.ts
+++ b/augmentos_cloud/packages/sdk/src/types/streams.ts
@@ -50,6 +50,11 @@ export enum StreamType {
   PHOTO_TAKEN = 'photo_taken',
 }
 
+export interface LocationStreamRequest {
+  stream: 'location_stream';
+  rate: 'standard' | 'high' | 'realtime' | 'tenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+}
+
 /**
  * Extended StreamType to support language-specific streams
  * This allows us to treat language-specific strings as StreamType values

--- a/augmentos_manager/ios/BleManager/LocationManager.swift
+++ b/augmentos_manager/ios/BleManager/LocationManager.swift
@@ -30,6 +30,25 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     
     // Start location updates (will only work if permission is already granted)
     locationManager.startUpdatingLocation()
+
+    // --- TEMPORARY TEST CODE ---
+    // add this line to see the faster updates in your xcode logs.
+    // you MUST remove this line before you create the pull request.
+    self.setHighAccuracyMode(enabled: true)
+    // -------------------------
+  }
+  
+  // this is the new function we're adding. it lets javascript turn on the high-power gps mode
+  public func setHighAccuracyMode(enabled: Bool) {
+    if enabled {
+      print("LocationManager: Enabling high accuracy mode")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+      locationManager.distanceFilter = kCLDistanceFilterNone
+    } else {
+      print("LocationManager: Disabling high accuracy mode, returning to standard")
+      locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      locationManager.distanceFilter = 2 // back to the default 2 meters
+    }
   }
   
   func setLocationChangedCallback(_ callback: @escaping () -> Void) {

--- a/augmentos_manager/ios/BleManager/LocationManager.swift
+++ b/augmentos_manager/ios/BleManager/LocationManager.swift
@@ -30,25 +30,6 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     
     // Start location updates (will only work if permission is already granted)
     locationManager.startUpdatingLocation()
-
-    // --- TEMPORARY TEST CODE ---
-    // add this line to see the faster updates in your xcode logs.
-    // you MUST remove this line before you create the pull request.
-    self.setHighAccuracyMode(enabled: true)
-    // -------------------------
-  }
-  
-  // this is the new function we're adding. it lets javascript turn on the high-power gps mode
-  public func setHighAccuracyMode(enabled: Bool) {
-    if enabled {
-      print("LocationManager: Enabling high accuracy mode")
-      locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
-      locationManager.distanceFilter = kCLDistanceFilterNone
-    } else {
-      print("LocationManager: Disabling high accuracy mode, returning to standard")
-      locationManager.desiredAccuracy = kCLLocationAccuracyBest
-      locationManager.distanceFilter = 2 // back to the default 2 meters
-    }
   }
   
   func setLocationChangedCallback(_ callback: @escaping () -> Void) {


### PR DESCRIPTION
new session.location module that provides developers with an API for both continuous tiered-rate location streaming (subscribeToStream) and on demand polling (getLatestLocation)

changes include creating the new LocationManager class and updating all necessary SDK types and message contracts to support sending these more robust location requests to the cloud. This work is entirely within the @augmentos/sdk package and should be fully backwards compatible with existing location functionality.

next steps: 
implementing the backend and native device logic to handle the new commands that the SDK can now send
 - cloud: enhance subscription.service.ts to process the new location rate data and arbitrate requests
 - client (ios + android): Update the native ServerComms and LocationManager/LocationSystem files to listen for the new cloud commands and reconfigure the GPS updates to match the new tiered system

full spec is here: https://docs.google.com/document/d/1GMVArsnOu0ESphzXKVka3jaQVo87Det2NY61w06gE4Y/edit?tab=t.hd5wcter8xqp